### PR TITLE
Hide floating auth buttons on landing page

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -609,7 +609,7 @@ import AuthenticatedApp from '../components/AuthenticatedApp.tsx';
       </footer>
     </main>
 
-    <AuthenticatedApp client:load />
+    <AuthenticatedApp client:load showUserProfile={false} showCreateButton={false} />
   </AppProvider>
 </MainLayout>
 


### PR DESCRIPTION
## Summary
- disable the floating authentication controls rendered by `AuthenticatedApp` on the marketing home page
- ensure only the in-header call-to-actions remain by hiding the user profile and create button overlays when the component loads on the landing page

## Testing
- `npm run build` *(fails: requires Astro adapter to be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0988cc79483208e879deec5adbcc2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The main page now hides the user profile section and the “Create” button, providing a cleaner, distraction-free view.
  * Introduced configuration to toggle visibility of the user profile and “Create” button for future flexibility.

* **UI**
  * Simplified initial screen by removing secondary actions from the page load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->