### PR TITLE
Fix Playwright auth validation messaging

### DIFF
--- a/src/pages/api/auth/login.ts
+++ b/src/pages/api/auth/login.ts
@@ -39,7 +39,7 @@ export const POST: APIRoute = async ({ request }) => {
       return new Response(
         JSON.stringify({
           success: false,
-          error: 'Email and password are required'
+          error: 'Todos los campos obligatorios deben ser completados'
         }),
         {
           status: 400,
@@ -59,7 +59,7 @@ export const POST: APIRoute = async ({ request }) => {
       return new Response(
         JSON.stringify({
           success: false,
-          error: 'Invalid email format'
+          error: 'El formato del correo electrónico no es válido'
         }),
         {
           status: 400,
@@ -75,7 +75,7 @@ export const POST: APIRoute = async ({ request }) => {
       return new Response(
         JSON.stringify({
           success: false,
-          error: result.error || 'Login failed'
+          error: 'Error al iniciar sesión'
         }),
         {
           status: 401,
@@ -148,7 +148,7 @@ export const POST: APIRoute = async ({ request }) => {
     return new Response(
       JSON.stringify({
         success: false,
-        error: 'Internal server error'
+        error: 'Error al iniciar sesión'
       }),
       {
         status: 500,

--- a/src/pages/login.astro
+++ b/src/pages/login.astro
@@ -191,18 +191,25 @@ import AppProvider from '../components/AppProvider.tsx';
       const toggleButtons = document.querySelectorAll('[onclick*="togglePasswordVisibility"]');
       toggleButtons.forEach(button => {
         const onclick = button.getAttribute('onclick');
-        if (onclick) {
-          const inputId = onclick.match(/'([^']+)'/)?.[1];
-          if (inputId) {
-            button.removeAttribute('onclick');
-            button.addEventListener('click', () => togglePasswordVisibility(inputId));
-          }
+        if (!onclick) {
+          return;
         }
+
+        const inputId = onclick.match(/'([^']+)'/)?.[1];
+        if (!inputId || button.dataset.passwordToggleBound === 'true') {
+          return;
+        }
+
+        button.dataset.passwordToggleBound = 'true';
+        button.addEventListener('click', () => togglePasswordVisibility(inputId));
       });
 
       // Login form submission
       const loginForm = document.getElementById('loginForm');
       if (loginForm) {
+        // Deshabilitar la validación nativa para mostrar mensajes personalizados
+        loginForm.setAttribute('novalidate', 'true');
+
         loginForm.addEventListener('submit', async function(e) {
           e.preventDefault();
 
@@ -218,14 +225,22 @@ import AppProvider from '../components/AppProvider.tsx';
             return;
           }
 
-          const email = emailInput.value;
+          const email = emailInput.value.trim();
           const password = passwordInput.value;
+
+          // Limpiar mensajes previos
+          errorMessage.classList.add('hidden');
+
+          if (!email || !password) {
+            errorText.textContent = 'Todos los campos obligatorios deben ser completados';
+            errorMessage.classList.remove('hidden');
+            return;
+          }
 
           // Show loading state
           loginButton.disabled = true;
           buttonText.textContent = 'Iniciando sesión...';
           loadingSpinner.classList.remove('hidden');
-          errorMessage.classList.add('hidden');
 
           try {
             const response = await fetch('/api/auth/login', {

--- a/src/pages/register.astro
+++ b/src/pages/register.astro
@@ -392,13 +392,17 @@ import AppProvider from '../components/AppProvider.tsx';
       const toggleButtons = document.querySelectorAll('[onclick*="togglePasswordVisibility"]');
       toggleButtons.forEach(button => {
         const onclick = button.getAttribute('onclick');
-        if (onclick) {
-          const inputId = onclick.match(/'([^']+)'/)?.[1];
-          if (inputId) {
-            button.removeAttribute('onclick');
-            button.addEventListener('click', () => togglePasswordVisibility(inputId));
-          }
+        if (!onclick) {
+          return;
         }
+
+        const inputId = onclick.match(/'([^']+)'/)?.[1];
+        if (!inputId || button.dataset.passwordToggleBound === 'true') {
+          return;
+        }
+
+        button.dataset.passwordToggleBound = 'true';
+        button.addEventListener('click', () => togglePasswordVisibility(inputId));
       });
     });
   </script>

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -102,7 +102,7 @@ router.post('/login', authRateLimit, async (req, res) => {
     if (!email || !password) {
       return res.status(400).json({
         success: false,
-        error: 'Email and password are required',
+        error: 'Todos los campos obligatorios deben ser completados',
         code: 'MISSING_CREDENTIALS'
       });
     }


### PR DESCRIPTION
## Summary
- ensure login and register password toggle buttons stay discoverable by tests while binding JS handlers safely
- harden the login form client script by disabling native validation, trimming email, and showing localized errors before sending requests
- return Spanish error strings for missing credentials from both the Astro API and Express auth route and wait for the user menu when checking authentication state in tests

## Testing
- npx playwright test tests/e2e/auth/auth.spec.ts --grep "visibilidad de contraseña"
- npx playwright test tests/e2e/auth/auth.spec.ts --grep "Login fallido"

------
https://chatgpt.com/codex/tasks/task_e_68d0abae53ac83208e6f95f0c9493bd1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Localized login error messages to Spanish.
  * Enhanced login form with custom client-side validation (native validation disabled, trimmed email, clearer required-field errors).

* Bug Fixes
  * Made password visibility toggle more reliable on login and register pages (guards and no duplicate bindings).
  * Adjusted error handling around loading states for consistent messaging.

* Tests
  * Refactored auth E2E flows for stability: preregistered users, explicit logout/login paths, visibility-based waits.
  * Improved storage/cookie cleanup and disabled native validation in test flows for consistent assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->