### PR TITLE
Ensure Astro type generation references content definitions

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="astro/client" />
+/// <reference path="content.d.ts" />


### PR DESCRIPTION
## Summary
- add the generated content definition file to `.astro/types.d.ts` so Astro's check command can consume the latest content typings

## Testing
- npm run type-check && echo "type-check succeeded"
- npx astro check

------
https://chatgpt.com/codex/tasks/task_e_68d1e2ee483083208bb5280bb8456ca8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript configuration to improve type resolution for content-related types, enhancing editor IntelliSense and developer experience.
  * No runtime behavior changes or user-facing impact.
  * No changes to public APIs or exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->