### PR TITLE
Add Playwright end-to-end tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,24 @@ jobs:
         CI: true
         NODE_ENV: test
 
+    - name: Install Playwright browsers
+      if: ${{ matrix['node-version'] == '20.x' }}
+      run: npx playwright install --with-deps
+
+    - name: Run end-to-end tests
+      if: ${{ matrix['node-version'] == '20.x' }}
+      run: npm run test:e2e -- --reporter=line
+      env:
+        CI: true
+
+    - name: Upload Playwright report
+      if: ${{ matrix['node-version'] == '20.x' && always() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 7
+
     - name: Upload test results
       uses: actions/upload-artifact@v4
       if: always()

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:interaction": "jest tests/interaction-tests.js",
     "test:all": "npm run test:design && npm run test:interaction",
     "test:parallel": "NODE_ENV=test node tests/run-parallel-tests.js",
+    "test:e2e": "playwright test",
     "test:ci": "npm run test:ci:unit",
     "test:health": "NODE_ENV=test node tests/health-check.js",
     "test:setup": "NODE_ENV=test node tests/setup-test-env.js",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: false,
+  timeout: 60_000,
+  expect: {
+    timeout: 10_000,
+  },
+  retries: process.env.CI ? 2 : 0,
+  reporter: [['list']],
+  use: {
+    baseURL: 'http://127.0.0.1:4321',
+    trace: 'on-first-retry',
+    video: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    colorScheme: 'light',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev -- --host 0.0.0.0 --port 4321',
+    url: 'http://127.0.0.1:4321',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+});

--- a/src/services/auth/tokenManager.ts
+++ b/src/services/auth/tokenManager.ts
@@ -1,6 +1,8 @@
 import crypto from 'crypto';
-import { JsonWebTokenError, sign, verify } from 'jsonwebtoken';
+import jwt from 'jsonwebtoken';
 import type { SignOptions } from 'jsonwebtoken';
+
+const { JsonWebTokenError, sign, verify } = jwt;
 
 import type { UsersService } from '../users.ts';
 import type { UserDocument } from '../../types/database.ts';

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('LinguaFlip end-to-end journey', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test('landing page displays hero content and CTAs', async ({ page }) => {
+    await test.step('Navigate to the landing page', async () => {
+      await page.goto('/');
+    });
+
+    await test.step('Verify hero heading and supporting text', async () => {
+      await expect(
+        page.getByRole('heading', { name: /Impulsa tu inglés con/i })
+      ).toBeVisible();
+      await expect(
+        page.getByText('flashcards inteligentes', { exact: false })
+      ).toBeVisible();
+    });
+
+    await test.step('Confirm primary call-to-action links to registration', async () => {
+      const primaryCta = page.getByRole('link', { name: 'Crear cuenta gratuita' });
+      await expect(primaryCta).toBeVisible();
+      await expect(primaryCta).toHaveAttribute('href', '/register');
+    });
+
+    await test.step('Ensure secondary navigation links are present', async () => {
+      await expect(page.getByRole('link', { name: 'Iniciar sesión' })).toBeVisible();
+      await expect(page.getByRole('link', { name: 'Empieza gratis' })).toHaveAttribute('href', '/register');
+    });
+  });
+
+  test('primary navigation anchors lead to the workflow section', async ({ page }) => {
+    await test.step('Open the landing page', async () => {
+      await page.goto('/');
+    });
+
+    await test.step('Jump to the workflow section using the navigation link', async () => {
+      const workflowLink = page.getByRole('link', { name: 'Cómo funciona' }).first();
+      await workflowLink.click();
+      await expect(page).toHaveURL(/#workflow/);
+    });
+
+    await test.step('Verify that the workflow heading is visible', async () => {
+      const workflowHeading = page.getByRole('heading', { name: 'Un flujo pensado para tu agenda' });
+      await workflowHeading.scrollIntoViewIfNeeded();
+      await expect(workflowHeading).toBeVisible();
+    });
+  });
+
+  test('study mode link navigates to the study page', async ({ page }) => {
+    await test.step('Open the landing page', async () => {
+      await page.goto('/');
+    });
+
+    await test.step('Follow the hero study link', async () => {
+      await page.getByRole('link', { name: 'Ver modo estudio' }).click();
+      await expect(page).toHaveURL(/\/study$/);
+    });
+
+    await test.step('Confirm study session content is rendered', async () => {
+      await expect(page.getByRole('heading', { name: 'Sesión de Estudio' })).toBeVisible();
+      await expect(page.getByText('Cargando flashcards...')).toBeVisible();
+      await expect(page.getByRole('link', { name: 'Volver al Dashboard' })).toBeVisible();
+    });
+  });
+
+  test('login form validation and password visibility toggle work as expected', async ({ page }) => {
+    await test.step('Open the login page', async () => {
+      await page.goto('/login');
+    });
+
+    await test.step('Submit the form without credentials to trigger validation', async () => {
+      await page.getByRole('button', { name: 'Iniciar Sesión', exact: true }).click();
+      const errorAlert = page.locator('#errorMessage');
+      await expect(errorAlert).toBeVisible();
+      await expect(errorAlert).toContainText('Todos los campos obligatorios deben ser completados');
+    });
+
+    await test.step('Toggle password visibility control', async () => {
+      const passwordInput = page.locator('#password');
+      const toggleButton = page.locator('button[onclick*="togglePasswordVisibility"]').first();
+      await toggleButton.click();
+      await expect(passwordInput).toHaveAttribute('type', 'text');
+      await toggleButton.click();
+      await expect(passwordInput).toHaveAttribute('type', 'password');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a Playwright configuration and npm script to run browser-based E2E checks
- cover landing page, navigation anchors, study flow, and login validation with a serial Playwright spec
- fix the jsonwebtoken import in the token manager so the dev server runs without module errors during tests
- run the Playwright end-to-end suite in CI by installing browsers on Node 20 and uploading the report artifact

## Testing
- npm run test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68d2096cde2883209e7e2cedfcc8000e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Added browser-based end-to-end tests covering landing page, navigation, study mode, and login validation, improving confidence in core user flows.
  - Enabled test reporting and artifacts for easier review of results.

- Chores
  - Integrated E2E tests into the CI pipeline, running on supported environments and uploading reports automatically.
  - Added a script to run E2E tests locally.

- Refactor
  - Minor internal import cleanup in authentication code with no user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->