### PR TITLE
Remove unsafe set:html usage and clean lint suppressions

### DIFF
--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -237,7 +237,6 @@ export function requireAdmin(req: Request, res: Response, next: NextFunction) {
 /**
  * User ownership middleware - ensures user can only access their own data
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function requireOwnership(
   req: Request,
   res: Response,
@@ -395,7 +394,6 @@ export function authLogging(req: Request, res: Response, next: NextFunction) {
 /**
  * Combined authentication middleware with all security features
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function secureAuth(required: boolean = true) {
   const middlewares = [securityHeaders, authCors, authLogging, authRateLimit];
 
@@ -411,7 +409,6 @@ export function secureAuth(required: boolean = true) {
 /**
  * Authentication error handler
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function authErrorHandler(
   err: Error,
   req: Request,

--- a/src/pages/api/auth/me.ts
+++ b/src/pages/api/auth/me.ts
@@ -95,12 +95,12 @@ export const GET: APIRoute = async ({ request }) => {
     }
 
     // Remove sensitive information before sending
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const {
-      password: _password,
-      refreshTokens: _refreshTokens,
-      ...safeUserData
-    } = userResult.data as Record<string, unknown>;
+    const safeUserData = {
+      ...(userResult.data as Record<string, unknown>),
+    };
+
+    delete safeUserData.password;
+    delete safeUserData.refreshTokens;
 
     SecurityAuditor.logSecurityEvent(
       'USER_INFO_REQUEST_SUCCESS',

--- a/src/pages/dashboard.astro
+++ b/src/pages/dashboard.astro
@@ -26,11 +26,8 @@ import Sidebar from '../components/Sidebar.astro';
   />
 
   <!-- Schema.org structured data -->
-  {/* eslint-disable-next-line astro/no-set-html-directive */}
-  <script
-    type="application/ld+json"
-    is:inline
-    set:html={JSON.stringify({
+  <script type="application/ld+json" is:inline>
+    {JSON.stringify({
       '@context': 'https://schema.org',
       '@type': 'WebApplication',
       name: 'LinguaFlip Dashboard',
@@ -39,7 +36,7 @@ import Sidebar from '../components/Sidebar.astro';
       applicationCategory: 'EducationalApplication',
       operatingSystem: 'Web Browser',
     })}
-  />
+  </script>
 
   <AppProvider client:only="react">
     <div

--- a/src/pages/data.astro
+++ b/src/pages/data.astro
@@ -24,16 +24,12 @@ import AppProvider from '../components/AppProvider.tsx';
   />
 
   <!-- Schema.org structured data -->
-  {/* eslint-disable-next-line astro/no-set-html-directive */}
-  <script
-    type="application/ld+json"
-    is:inline
-    set:html={JSON.stringify({
+  <script type="application/ld+json" is:inline>
+    {JSON.stringify({
       '@context': 'https://schema.org',
       '@type': 'WebApplication',
       name: 'LinguaFlip Data Management',
-      description:
-        'Herramientas para gestionar y respaldar datos de aprendizaje',
+      description: 'Herramientas para gestionar y respaldar datos de aprendizaje',
       applicationCategory: 'EducationalApplication',
       operatingSystem: 'Web Browser',
       featureList: [
@@ -43,7 +39,7 @@ import AppProvider from '../components/AppProvider.tsx';
         'Restauración de progreso',
       ],
     })}
-  />
+  </script>
 
   <AppProvider client:only="react">
     <div

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -64,10 +64,8 @@ import AuthenticatedApp from '../components/AuthenticatedApp.tsx';
   <meta name="apple-mobile-web-app-title" content="LinguaFlip" />
 
   <!-- Schema.org structured data -->
-  <script
-    type="application/ld+json"
-    is:inline
-    set:html={JSON.stringify({
+  <script type="application/ld+json" is:inline>
+    {JSON.stringify({
       '@context': 'https://schema.org',
       '@type': 'WebApplication',
       name: 'LinguaFlip',
@@ -96,13 +94,11 @@ import AuthenticatedApp from '../components/AuthenticatedApp.tsx';
       ],
       screenshot: 'https://linguaflip.app/screenshot.jpg',
     })}
-  />
+  </script>
 
   <!-- Breadcrumbs Schema -->
-  <script
-    type="application/ld+json"
-    is:inline
-    set:html={JSON.stringify({
+  <script type="application/ld+json" is:inline>
+    {JSON.stringify({
       '@context': 'https://schema.org',
       '@type': 'BreadcrumbList',
       itemListElement: [
@@ -114,7 +110,7 @@ import AuthenticatedApp from '../components/AuthenticatedApp.tsx';
         },
       ],
     })}
-  />
+  </script>
 
   <AppProvider client:load>
     <main

--- a/src/pages/settings.astro
+++ b/src/pages/settings.astro
@@ -87,11 +87,8 @@ if (!currentProfileStore.get()) {
   />
 
   <!-- Schema.org structured data -->
-  {/* eslint-disable-next-line astro/no-set-html-directive */}
-  <script
-    type="application/ld+json"
-    is:inline
-    set:html={JSON.stringify({
+  <script type="application/ld+json" is:inline>
+    {JSON.stringify({
       '@context': 'https://schema.org',
       '@type': 'WebApplication',
       name: 'LinguaFlip Settings',
@@ -107,7 +104,7 @@ if (!currentProfileStore.get()) {
         'Metas de estudio',
       ],
     })}
-  />
+  </script>
 
   <AppProvider client:only="react">
     <div


### PR DESCRIPTION
## Summary
- replace Astro schema scripts to inline JSON stringification without `set:html`, resolving lint errors across marketing pages
- sanitize the auth `me` API response by copying user data and deleting sensitive fields without unused variables
- remove stale ESLint disable directives from authentication middleware helpers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2a9579a7c8320927c084b8cca46ed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Switched JSON-LD embedding to standard inline scripts across key pages for more consistent structured data parsing by search engines (no UI changes).
  - Streamlined handling to ensure sensitive fields are omitted from account data responses (behavior unchanged).
- Style
  - Removed unnecessary lint-disable comments for cleaner code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->